### PR TITLE
feat: drop support for py38/py39

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4"
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: "Install dependencies"
         run: "pip install -r requirements.txt"
       - name: "Build"

--- a/anysqlite/_core.py
+++ b/anysqlite/_core.py
@@ -70,9 +70,7 @@ class Cursor:
     @property
     def description(
         self,
-    ) -> tp.Union[
-        tp.Tuple[tp.Tuple[str, None, None, None, None, None, None], ...], tp.Any
-    ]:
+    ) -> tuple[tuple[str, None, None, None, None, None, None], ...] | tp.Any:
         return self._real_cursor.description
 
     @property
@@ -111,7 +109,7 @@ class Cursor:
             self._real_cursor.fetchone, limiter=self._limiter
         )
 
-    async def fetchmany(self, size: tp.Union[int, None] = 1) -> tp.Any:
+    async def fetchmany(self, size: int | None = 1) -> tp.Any:
         return await to_thread.run_sync(
             self._real_cursor.fetchmany, size, limiter=self._limiter
         )
@@ -123,7 +121,7 @@ class Cursor:
 
 
 async def connect(
-    database: tp.Union[str, bytes, Path], **kwargs: tp.Any
+    database: str | bytes | Path, **kwargs: tp.Any
 ) -> "Connection":
     kwargs["check_same_thread"] = False
     real_connection = await to_thread.run_sync(

--- a/anysqlite/_core.py
+++ b/anysqlite/_core.py
@@ -40,7 +40,10 @@ class Connection:
 
     async def execute(self, sql: str, parameters: tp.Iterable[tp.Any] = ()) -> "Cursor":
         real_cursor = await to_thread.run_sync(
-            self._real_connection.execute, sql, parameters, limiter=self._limiter
+            self._real_connection.execute,  # type: ignore[arg-type]
+            sql,
+            parameters,
+            limiter=self._limiter,
         )
         return Cursor(real_cursor, self._limiter)
 
@@ -48,7 +51,7 @@ class Connection:
         self, sql: str, seq_of_parameters: tp.Iterable[tp.Iterable[tp.Any]]
     ) -> "Cursor":
         real_cursor = await to_thread.run_sync(
-            self._real_connection.executemany,
+            self._real_connection.executemany,  # type: ignore[arg-type]
             sql,
             seq_of_parameters,
             limiter=self._limiter,
@@ -86,7 +89,10 @@ class Cursor:
 
     async def execute(self, sql: str, parameters: tp.Iterable[tp.Any] = ()) -> "Cursor":
         real_cursor = await to_thread.run_sync(
-            self._real_cursor.execute, sql, parameters, limiter=self._limiter
+            self._real_cursor.execute,  # type: ignore[arg-type]
+            sql,
+            parameters,
+            limiter=self._limiter,
         )
         return Cursor(real_cursor, self._limiter)
 
@@ -94,7 +100,10 @@ class Cursor:
         self, sql: str, seq_of_parameters: tp.Iterable[tp.Iterable[tp.Any]]
     ) -> "Cursor":
         real_cursor = await to_thread.run_sync(
-            self._real_cursor.executemany, sql, seq_of_parameters, limiter=self._limiter
+            self._real_cursor.executemany,  # type: ignore[arg-type]
+            sql,
+            seq_of_parameters,
+            limiter=self._limiter,
         )
         return Cursor(real_cursor, self._limiter)
 
@@ -120,9 +129,7 @@ class Cursor:
         )
 
 
-async def connect(
-    database: str | bytes | Path, **kwargs: tp.Any
-) -> "Connection":
+async def connect(database: str | bytes | Path, **kwargs: tp.Any) -> "Connection":
     kwargs["check_same_thread"] = False
     real_connection = await to_thread.run_sync(
         partial(sqlite3.connect, database, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = ''
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = []
 authors = [
   { name = "Karen Petrosyan", email = "kar.petrosyanpy@gmail.com" },
@@ -16,11 +16,11 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -81,6 +81,8 @@ exclude_also = [
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
 select = [
     "E",
     "F",
@@ -88,5 +90,5 @@ select = [
     "I"
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 -e .
 
-black==23.9.1
-mypy==1.5.1
-pytest==7.4.2
-ruff==0.0.291
+black==26.5.1
+mypy==2.1.0
+pytest==9.0.3
+ruff==0.15.17
 trio>0.20.0
-hatch==1.7.0
+hatch==1.17.0
+typing-extensions==4.15.0

--- a/scripts/check
+++ b/scripts/check
@@ -1,5 +1,5 @@
 #! /bin/bash -ex
 
 black --check --diff tests anysqlite
-ruff tests anysqlite
+ruff check tests anysqlite
 mypy tests anysqlite

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,4 +1,4 @@
 #! /bin/bash -ex
 
 black anysqlite tests
-ruff --fix anysqlite tests
+ruff check --fix anysqlite tests


### PR DESCRIPTION
# Description

1. Change requires-python in pyproject.toml
2. Edit python-version of github workflow
3. Upgrade deps in requirements.txt
4. Use `ruff check` instead of `ruff`
5. Run `ruff check --fix --extend-select=UP anysqlite tests` to apply new style type hints
6. Add some `type:ignore` to fix mypy complaints